### PR TITLE
Add tessconfigs/ and configs/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tessconfigs/
+configs/


### PR DESCRIPTION
This way you can:

    ln -s /usr/share/tesseract-ocr/4.00/tessdata/configs .
    ln -s /usr/share/tesseract-ocr/4.00/tessdata/tessconfigs .

and use this repo as `$TESSDATA_PREFIX` without git complaining that
there are untracked files.