### PR TITLE
Removed Inaccessible Submodules

### DIFF
--- a/configs
+++ b/configs
@@ -1,1 +1,0 @@
-tessconfigs/configs

--- a/pdf.ttf
+++ b/pdf.ttf
@@ -1,1 +1,0 @@
-tessconfigs/pdf.ttf


### PR DESCRIPTION
Trying to link only part of a [tessconfigs](https://github.com/tesseract-ocr/tessconfigs) repository - that are ([`configs`](https://github.com/tesseract-ocr/tessconfigs/tree/main/configs) and [`pdf.ttf`](https://github.com/tesseract-ocr/tessconfigs/blob/main/pdf.ttf)) - can't be done this way.
Cloning only part of a repo is not supported. Can only point to the whole repository. References [[1](https://stackoverflow.com/a/5303850/16349299), [2](https://stackoverflow.com/a/5303867/16349299)]

####   In addition tessconfig is already linked!
